### PR TITLE
Added industry job fetcher

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -134,6 +134,9 @@ func doCmd(cmd *cobra.Command, args []string) {
 		go transactionFetcher.StartLoop()
 	}
 
+	jobsFetcher := datafetch.NewIndustryJobsFetcher(app.CorporationID)
+	go jobsFetcher.StartLoop()
+
 	//go app.TransactionLoop()
 	//go ContractsLoop()
 

--- a/datafetch/industry_jobs.go
+++ b/datafetch/industry_jobs.go
@@ -1,0 +1,140 @@
+package datafetch
+
+import (
+	"context"
+	"time"
+
+	"github.com/antihax/goesi"
+	"github.com/antihax/goesi/esi"
+	"github.com/antihax/goesi/optional"
+	"github.com/oxisto/titan/cache"
+	"github.com/oxisto/titan/db"
+	"github.com/oxisto/titan/model"
+	"github.com/sirupsen/logrus"
+)
+
+type industryJobsFetcher struct {
+	corporationID int32
+
+	log      *logrus.Entry
+	lastETag string
+}
+
+func NewIndustryJobsFetcher(corporationID int32) DataFetcher {
+	return &industryJobsFetcher{
+		corporationID: corporationID,
+		log: log.WithFields(logrus.Fields{
+			"data":          "industry-jobs",
+			"corporationID": corporationID,
+		}),
+	}
+}
+
+func (i industryJobsFetcher) StartLoop() {
+	for {
+		i.log.Printf("Fetching industry jobs...")
+		duration, err := i.Fetch()
+
+		if err != nil {
+			i.log.Printf("An error occured while fetching jobs: %v", err)
+		}
+
+		if duration < 0 {
+			duration = i.MaxCacheTime()
+		}
+
+		i.log.Printf("Waiting for %.2f minutes until next fetch", duration.Minutes())
+
+		time.Sleep(duration)
+	}
+}
+
+func (i industryJobsFetcher) MaxCacheTime() time.Duration {
+	return time.Minute * 5
+}
+
+func (i *industryJobsFetcher) Fetch() (time.Duration, error) {
+	// find access token for corporation
+	accessToken := model.AccessToken{}
+	err := cache.GetAccessTokenForCorporation(i.corporationID, &accessToken)
+	if err != nil {
+		return i.MaxCacheTime(), err
+	}
+
+	var options esi.GetCorporationsCorporationIdIndustryJobsOpts
+	options.IncludeCompleted = optional.NewBool(true)
+
+	if i.lastETag != "" {
+		options.IfNoneMatch = optional.NewString(i.lastETag)
+	}
+
+	response, httpResponse, err := cache.ESI.IndustryApi.GetCorporationsCorporationIdIndustryJobs(
+		context.WithValue(context.Background(),
+			goesi.ContextAccessToken,
+			accessToken.Token),
+		i.corporationID,
+		&options)
+	if err != nil {
+		return i.MaxCacheTime(), err
+	}
+
+	t, err := time.Parse(time.RFC1123, httpResponse.Header.Get("Expires"))
+	if err != nil {
+		return i.MaxCacheTime(), err
+	}
+
+	limitFields := logrus.Fields{
+		"esi-err-remain": httpResponse.Header.Get("x-esi-error-limit-remain"),
+		"esi-err-reset":  httpResponse.Header.Get("x-esi-error-limit-reset"),
+	}
+
+	if httpResponse.StatusCode != 304 {
+		i.log.WithFields(limitFields).Infof("Retrieved %d industry jobs", len(response))
+
+		// store the ETag
+		i.lastETag = httpResponse.Header.Get("etag")
+
+		// loop through all jobs
+		for _, t := range response {
+			job := model.IndustryJob{
+				ActivityID:           t.ActivityId,
+				BlueprintID:          t.BlueprintId,
+				BlueprintTypeID:      t.BlueprintTypeId,
+				CompletedCharacterID: t.CompletedCharacterId,
+				Cost:                 t.Cost,
+				Duration:             t.Duration,
+				EndDate:              t.EndDate,
+				FacilityID:           t.FacilityId,
+				InstallerID:          t.InstallerId,
+				LicensedRuns:         t.LicensedRuns,
+				LocationID:           t.LocationId,
+				OutputLocationID:     t.OutputLocationId,
+				Probability:          t.Probability,
+				ProductTypeID:        t.ProductTypeId,
+				Runs:                 t.Runs,
+				JobID:                t.JobId,
+				StartDate:            t.StartDate,
+				Status:               t.Status,
+				SuccesfulRuns:        t.SuccessfulRuns,
+			}
+
+			if !t.CompletedDate.IsZero() {
+				job.CompletedDate = &t.CompletedDate
+			}
+
+			if !t.PauseDate.IsZero() {
+				job.PauseDate = &t.PauseDate
+			}
+
+			i.log.Debugf("Discovered industry job %d (%d, %d)", job.JobID, job.ActivityID, job.BlueprintTypeID)
+
+			if err := db.UpdateIndustryJob(&job); err != nil {
+				i.log.Printf("Could not update industry job ID %d: %v", job.JobID, err)
+			}
+		}
+	} else {
+		i.log.WithFields(limitFields).Info("Industry jobs have not changed")
+	}
+
+	return time.Until(t), nil
+}

--- a/db/jobs.go
+++ b/db/jobs.go
@@ -1,0 +1,58 @@
+package db
+
+import "github.com/oxisto/titan/model"
+
+func GetIndustryJobs(corporationID int32) ([]*model.IndustryJobs, error) {
+	return nil, nil
+}
+
+func UpdateIndustryJob(job *model.IndustryJob) error {
+	_, err := pdb.Exec(`INSERT INTO
+	"industryJobs"
+	VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+	ON CONFLICT("jobID") DO UPDATE
+	SET
+		"activityID" = $2,
+		"completedCharacterID" = $3,
+		"completedDate" = $4,
+		"cost" = $5,
+		"duration" = $6,
+		"endDate" = $7,
+		"facilityID" = $8,
+		"installerID" = $9,
+		"locationID" = $10,
+		"blueprintID" = $11,
+		"blueprintTypeID" = $12,
+		"startDate" = $13,
+		"pauseDate" = $14,
+		"licensedRuns" = $15,
+		"outputLocationID" = $16,
+		"probability" = $17,
+		"productTypeID" = $18,
+		"runs" = $19,
+		"succesfulRuns" = $20,
+		"status" = $21`,
+		job.JobID,
+		job.ActivityID,
+		job.CompletedCharacterID,
+		job.CompletedDate,
+		job.Cost,
+		job.Duration,
+		job.EndDate,
+		job.FacilityID,
+		job.InstallerID,
+		job.LocationID,
+		job.BlueprintID,
+		job.BlueprintTypeID,
+		job.StartDate,
+		job.PauseDate,
+		job.LicensedRuns,
+		job.OutputLocationID,
+		job.Probability,
+		job.ProductTypeID,
+		job.Runs,
+		job.SuccesfulRuns,
+		job.Status)
+
+	return err
+}

--- a/db/jobs.go
+++ b/db/jobs.go
@@ -2,8 +2,20 @@ package db
 
 import "github.com/oxisto/titan/model"
 
-func GetIndustryJobs(corporationID int32) ([]*model.IndustryJobs, error) {
-	return nil, nil
+func GetIndustryJobs(corporationID int32) ([]*model.IndustryJobWithTypeNames, error) {
+	jobs := []*model.IndustryJobWithTypeNames{}
+
+	err := pdb.Select(&jobs, `SELECT
+		"industryJobs".*,
+		"blueprintTypes"."typeName" AS "blueprintTypeName",
+		"productTypes"."typeName" AS "productTypeName"
+	FROM
+		"industryJobs"
+		LEFT JOIN evesde."invTypes" AS "blueprintTypes" ON ("blueprintTypes"."typeID" = "industryJobs"."blueprintTypeID")
+		LEFT JOIN evesde."invTypes" AS "productTypes" ON ("productTypes"."typeID" = "industryJobs"."productTypeID")
+	`)
+
+	return jobs, err
 }
 
 func UpdateIndustryJob(job *model.IndustryJob) error {

--- a/frontend/src/app/industry/industry.service.ts
+++ b/frontend/src/app/industry/industry.service.ts
@@ -18,10 +18,14 @@ export class IndustryService {
         jobs: new Map(Object.entries(data.jobs).map(entry => {
           entry[1] = Object.assign(new IndustryJob(), {
             ...entry[1],
-            endDate: new Date(entry[1].endDate * 1000),
-            startDate: new Date(entry[1].startDate * 1000),
-            completedDate: new Date(entry[1].completedDate * 1000),
-            pauseDate: new Date(entry[1].pauseDate * 1000)
+            endDate: Date.parse(entry[1].endDate),
+            startDate: Date.parse(entry[1].startDate),
+            completedDate: entry[1].completedDate != null ? Date.parse(entry[1].completedDate) : null,
+            pauseDate: entry[1].pauseDate != null ? Date.parse(entry[1].pauseDate) : null,
+            blueprint: {
+              typeID: entry[1].blueprintTypeID,
+              typeName: entry[1].blueprintTypeName,
+            }
           });
           return entry;
         }))

--- a/frontend/src/app/industry/industry.ts
+++ b/frontend/src/app/industry/industry.ts
@@ -1,13 +1,13 @@
 export class IndustryJobs {
     constructor(public jobs?: Map<string, IndustryJob>,
-                public corporationID?: number) { }
+        public corporationID?: number) { }
 }
 
 export class IndustryJob {
     constructor(public status?: string,
-                public endDate?: Date,
-                public startDate?: Date,
-                public completedDate?: Date,
-                public pauseDate?: Date
+        public endDate?: Date,
+        public startDate?: Date,
+        public completedDate?: Date,
+        public pauseDate?: Date
     ) { }
 }

--- a/frontend/src/app/industry/industry.ts
+++ b/frontend/src/app/industry/industry.ts
@@ -1,13 +1,13 @@
 export class IndustryJobs {
     constructor(public jobs?: Map<string, IndustryJob>,
-        public corporationID?: number) { }
+                public corporationID?: number) { }
 }
 
 export class IndustryJob {
     constructor(public status?: string,
-        public endDate?: Date,
-        public startDate?: Date,
-        public completedDate?: Date,
-        public pauseDate?: Date
+                public endDate?: Date,
+                public startDate?: Date,
+                public completedDate?: Date,
+                public pauseDate?: Date
     ) { }
 }

--- a/model/industry.go
+++ b/model/industry.go
@@ -34,17 +34,27 @@ type IndustryJobs struct {
 }
 
 type IndustryJob struct {
-	ActivityID       int32   `json:"activityID"`
-	Blueprint        *Type   `json:"blueprint"`
-	StartDate        int64   `json:"startDate"`
-	EndDate          int64   `json:"endDate"`
-	CompletedDate    int64   `json:"completedDate"`
-	PauseDate        int64   `json:"pausedDate"`
-	LicensedRuns     int     `json:"licensedRuns"`
-	OutputLocationID int64   `json:"outputLocationID"`
-	Probability      float32 `json:"probability"`
-	SuccesfulRuns    int     `json:"succesfulRuns"`
-	Status           string  `json:"status"`
+	JobID                int32      `json:"jobID"`
+	ActivityID           int32      `json:"activityID"`
+	CompletedCharacterID int32      `json:"completedCharacterID"`
+	CompletedDate        *time.Time `json:"completedDate"`
+	Cost                 float64    `json:"cost"`
+	Duration             int32      `json:"duration"`
+	EndDate              time.Time  `json:"endDate"`
+	FacilityID           int64      `json:"facilityID"`
+	InstallerID          int32      `json:"installerID"`
+	LocationID           int64      `json:"locationID"`
+	BlueprintID          int64      `json:"blueprintID"`
+	BlueprintTypeID      int32      `json:"blueprintTypeID"`
+	StartDate            time.Time  `json:"startDate"`
+	PauseDate            *time.Time `json:"pausedDate"`
+	LicensedRuns         int32      `json:"licensedRuns"`
+	OutputLocationID     int64      `json:"outputLocationID"`
+	Probability          float32    `json:"probability"`
+	ProductTypeID        int32      `json:"productTypeID"`
+	Runs                 int32      `json:"runs"`
+	SuccesfulRuns        int32      `json:"succesfulRuns"`
+	Status               string     `json:"status"`
 }
 
 func (i *IndustryJobs) ID() int32 {

--- a/model/industry.go
+++ b/model/industry.go
@@ -28,47 +28,35 @@ func (i *SystemCostIndex) HashKey() string {
 }
 
 type IndustryJobs struct {
-	expireDate    *time.Time
-	CorporationID int32                  `json:"corporationID"`
-	Jobs          map[string]IndustryJob `json:"jobs"`
+	CorporationID int32                       `json:"corporationID"`
+	Jobs          []*IndustryJobWithTypeNames `json:"jobs"`
 }
 
 type IndustryJob struct {
-	JobID                int32      `json:"jobID"`
-	ActivityID           int32      `json:"activityID"`
-	CompletedCharacterID int32      `json:"completedCharacterID"`
-	CompletedDate        *time.Time `json:"completedDate"`
-	Cost                 float64    `json:"cost"`
-	Duration             int32      `json:"duration"`
-	EndDate              time.Time  `json:"endDate"`
-	FacilityID           int64      `json:"facilityID"`
-	InstallerID          int32      `json:"installerID"`
-	LocationID           int64      `json:"locationID"`
-	BlueprintID          int64      `json:"blueprintID"`
-	BlueprintTypeID      int32      `json:"blueprintTypeID"`
-	StartDate            time.Time  `json:"startDate"`
-	PauseDate            *time.Time `json:"pausedDate"`
-	LicensedRuns         int32      `json:"licensedRuns"`
-	OutputLocationID     int64      `json:"outputLocationID"`
-	Probability          float32    `json:"probability"`
-	ProductTypeID        int32      `json:"productTypeID"`
-	Runs                 int32      `json:"runs"`
-	SuccesfulRuns        int32      `json:"succesfulRuns"`
-	Status               string     `json:"status"`
+	JobID                int32      `json:"jobID" db:"jobID"`
+	ActivityID           int32      `json:"activityID" db:"activityID"`
+	CompletedCharacterID int32      `json:"completedCharacterID" db:"completedCharacterID"`
+	CompletedDate        *time.Time `json:"completedDate" db:"completedDate"`
+	Cost                 float64    `json:"cost" db:"cost"`
+	Duration             int32      `json:"duration" db:"duration"`
+	EndDate              time.Time  `json:"endDate" db:"endDate"`
+	FacilityID           int64      `json:"facilityID" db:"facilityID"`
+	InstallerID          int32      `json:"installerID" db:"installerID"`
+	LocationID           int64      `json:"locationID" db:"locationID"`
+	BlueprintID          int64      `json:"blueprintID" db:"blueprintID"`
+	BlueprintTypeID      int32      `json:"blueprintTypeID" db:"blueprintTypeID"`
+	StartDate            time.Time  `json:"startDate" db:"startDate"`
+	PauseDate            *time.Time `json:"pauseDate" db:"pauseDate"`
+	LicensedRuns         int32      `json:"licensedRuns" db:"licensedRuns"`
+	OutputLocationID     int64      `json:"outputLocationID" db:"outputLocationID"`
+	Probability          float32    `json:"probability" db:"probability"`
+	ProductTypeID        int32      `json:"productTypeID" db:"productTypeID"`
+	Runs                 int32      `json:"runs" db:"runs"`
+	SuccesfulRuns        int32      `json:"succesfulRuns" db:"succesfulRuns"`
+	Status               string     `json:"status" db:"status"`
 }
 
-func (i *IndustryJobs) ID() int32 {
-	return i.CorporationID
-}
-
-func (i *IndustryJobs) ExpiresOn() *time.Time {
-	return i.expireDate
-}
-
-func (i *IndustryJobs) SetExpire(t *time.Time) {
-	i.expireDate = t
-}
-
-func (i *IndustryJobs) HashKey() string {
-	return fmt.Sprintf("industry-jobs:%d", i.ID())
+type IndustryJobWithTypeNames struct {
+	*IndustryJob
+	BlueprintTypeName string `json:"blueprintTypeName" db:"blueprintTypeName"`
 }

--- a/routes/industry.go
+++ b/routes/industry.go
@@ -27,7 +27,12 @@ import (
 func GetIndustryJobs(c *gin.Context) {
 	character := c.Value(CharacterContext).(*model.Character)
 
-	jobs, err := db.GetIndustryJobs(character.CorporationID)
+	jobList, err := db.GetIndustryJobs(character.CorporationID)
+
+	jobs := model.IndustryJobs{
+		CorporationID: character.CorporationID,
+		Jobs:          jobList,
+	}
 
 	JSON(c, http.StatusOK, jobs, err)
 }

--- a/routes/industry.go
+++ b/routes/industry.go
@@ -20,15 +20,14 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/oxisto/titan/cache"
+	"github.com/oxisto/titan/db"
 	"github.com/oxisto/titan/model"
 )
 
 func GetIndustryJobs(c *gin.Context) {
 	character := c.Value(CharacterContext).(*model.Character)
-	jobs := &model.IndustryJobs{}
 
-	err := cache.GetIndustryJobs(character.CharacterID, character.CorporationID, jobs)
+	jobs, err := db.GetIndustryJobs(character.CorporationID)
 
 	JSON(c, http.StatusOK, jobs, err)
 }

--- a/sql/public.sql
+++ b/sql/public.sql
@@ -37,3 +37,30 @@ CREATE TABLE public.transactions (
         "transactionID"
     )
 )
+
+CREATE TABLE public."industryJobs" (
+    "jobID" integer NOT NULL,
+    "activityID" integer NOT NULL,
+	"completedCharacterID" integer NOT NULL,
+	"completedDate" timestamp WITH time zone,
+	"cost" double precision NOT NULL,
+	"duration" integer NOT NULL,
+	"endDate" timestamp WITH time zone NOT NULL,
+	"facilityID" bigint NOT NULL,
+	"installerID" integer NOT NULL,
+	"locationID" bigint NOT NULL,
+	"blueprintID" bigint NOT NULL,
+	"blueprintTypeID" integer NOT NULL,
+	"startDate" timestamp WITH time zone NOT NULL,
+	"pauseDate" timestamp WITH time zone,
+	"licensedRuns" integer NOT NULL,
+	"outputLocationID" bigint NOT NULL,
+	"probability" real NOT NULL,
+	"productTypeID" integer NOT NULL,
+	"runs" integer NOT NULL,
+	"succesfulRuns" integer NOT NULL,
+	"status" text COLLATE pg_catalog. "default" NOT NULL,
+    CONSTRAINT industrJobs_pkey PRIMARY KEY (
+        "jobID"
+    )
+)


### PR DESCRIPTION
Will fetch all industry jobs for the corporation every 5 minutes. This also adds ETag support for all fetchers, to ease the burden on ESI.

- [x] Fetching and storing jobs
- [x] Retrieving them from the DB

Fixes #459
